### PR TITLE
Multiple zones support

### DIFF
--- a/viastitching_dialog.py
+++ b/viastitching_dialog.py
@@ -410,7 +410,14 @@ class ViaStitchingDialog(viastitching_gui):
         zone_name = self.area.GetZoneName()
         wx.LogMessage(f"Zone name: {zone_name}")
         if zone_name == "":
-            zone_name = f"zone{random.randint(0,100)}"
+            for i in range(1000):
+                candidate_name = f"stitch_zone_{i}"
+                if candidate_name not in self.config.keys():
+                    zone_name = candidate_name
+                    break
+            else:
+                wx.LogError("Tried 1000 different names and all were taken. Please give a name to the zone.")
+                self.Destroy()
             self.area.SetZoneName(zone_name)
 
         config = {

--- a/viastitching_dialog.py
+++ b/viastitching_dialog.py
@@ -5,6 +5,7 @@
 # (c) Michele Santucci 2019
 #
 import random
+from json import JSONDecodeError
 
 import wx
 import pcbnew
@@ -25,8 +26,8 @@ import pathlib
 _ = gettext.gettext
 __version__ = "0.2"
 __timecode__ = 1972
-__viagroupname__ = "VIA_STITCHING_GROUP"
-default_filename = "defaults.json"
+__viagroupname_base__ = "VIA_STITCHING_GROUP"
+__plugin_config_layer_name__ = "plugins.config"
 
 
 class ViaStitchingDialog(viastitching_gui):
@@ -36,6 +37,7 @@ class ViaStitchingDialog(viastitching_gui):
         """Initialize the brand new instance."""
 
         super(ViaStitchingDialog, self).__init__(None)
+        self.viagroupname = None
         self.SetTitle(_(u"ViaStitching v{0}").format(__version__))
         self.Bind(wx.EVT_CLOSE, self.onCloseWindow)
         self.m_btnCancel.Bind(wx.EVT_BUTTON, self.onCloseWindow)
@@ -47,15 +49,27 @@ class ViaStitchingDialog(viastitching_gui):
         self.clearance = 0
         self.board_edges = []
         self.default_file_path = f"{pathlib.Path(__file__).parent.resolve()}/{default_filename}"
+        self.config_layer = 0
+        self.config_textbox = None
+        self.area = None
+        self.net = None
+        self.config = {}
+
+        self.getConfigLayer()
 
         for d in pcbnew.GetBoard().GetDrawings():
             if d.GetLayerName() == 'Edge.Cuts':
                 self.board_edges.append(d)
+            if d.GetLayerName() == __plugin_config_layer_name__:
+                try:
+                    new_config = json.loads(d.GetText())
+                    if "ViaStitching" in new_config.keys():
+                        self.config_textbox = d
+                        self.config = new_config
+                except JSONDecodeError:
+                    pass
+        wx.LogMessage(f"Got config: {self.config}")
 
-        # Search trough groups
-        for group in self.board.Groups():
-            if group.GetName() == __viagroupname__:
-                self.pcb_group = group
 
         # Use the same unit set int PCBNEW
         self.ToUserUnit = None
@@ -80,17 +94,30 @@ class ViaStitchingDialog(viastitching_gui):
             wx.MessageBox(_(u"Not a valid frame"))
             self.Destroy()
 
-        try:
-            defaults = {}
-            with open(self.default_file_path, "r") as def_file:
-                defaults = json.load(def_file)
-        except Exception:
-            pass
+            # Check for selected area
+        if not self.GetAreaConfig():
+            wx.MessageBox(_(u"Please select a valid area"))
+            self.Destroy()
+        else:
+            # Populate nets checkbox
+            self.PopulateNets()
 
-        self.m_txtVSpacing.SetValue(defaults.get("VSpacing", "3"))
-        self.m_txtHSpacing.SetValue(defaults.get("HSpacing", "3"))
-        self.m_txtClearance.SetValue(defaults.get("Clearance", "0"))
-        self.m_chkRandomize.SetValue(defaults.get("Randomize", False))
+        wx.LogMessage(f"Area: {self.area}")
+        defaults = self.config.get(self.area.GetZoneName(), None)
+        self.viagroupname = __viagroupname_base__ + self.area.GetZoneName()
+
+        # Search trough groups
+        for group in self.board.Groups():
+            if group.GetName() == self.viagroupname:
+                self.pcb_group = group
+
+        wx.LogMessage(f"Got defaults: {defaults}")
+
+        if defaults is not None:
+            self.m_txtVSpacing.SetValue(defaults.get("VSpacing", "3"))
+            self.m_txtHSpacing.SetValue(defaults.get("HSpacing", "3"))
+            self.m_txtClearance.SetValue(defaults.get("Clearance", "0"))
+            self.m_chkRandomize.SetValue(defaults.get("Randomize", False))
 
         # Get default Vias dimensions
         via_dim_list = self.board.GetViasDimensionsList()
@@ -104,17 +131,11 @@ class ViaStitchingDialog(viastitching_gui):
         self.m_txtViaSize.SetValue("%.6f" % self.ToUserUnit(via_dims.m_Diameter))
         self.m_txtViaDrillSize.SetValue("%.6f" % self.ToUserUnit(via_dims.m_Drill))
         via_dim_list.push_back(via_dims)
-        self.area = None
-        self.net = None
         self.overlappings = None
 
-        # Check for selected area
-        if not self.GetAreaConfig():
-            wx.MessageBox(_(u"Please select a valid area"))
-            self.Destroy()
-        else:
-            # Populate nets checkbox
-            self.PopulateNets()
+        wx.LogMessage("Finished init...")
+
+
 
     def GetOverlappingItems(self):
         """Collect overlapping items.
@@ -173,6 +194,7 @@ class ViaStitchingDialog(viastitching_gui):
                     return False
                 self.area = area
                 self.net = area.GetNetname()
+                wx.LogMessage(f"Area: {self.area}!")
                 return True
 
         return False
@@ -213,7 +235,7 @@ class ViaStitchingDialog(viastitching_gui):
                 # if undo and (item.GetTimeStamp() == __timecode__):
                 if undo and (self.pcb_group is not None):
                     group = item.GetParentGroup()
-                    if (group is not None and group.GetName() == __viagroupname__):
+                    if (group is not None and group.GetName() == self.viagroupname):
                         self.board.Remove(item)
                         viacount += 1
                         # commit.Remove(item)
@@ -384,26 +406,45 @@ class ViaStitchingDialog(viastitching_gui):
 
     def onProcessAction(self, event):
         """Manage main button (Ok) click event."""
+        wx.LogMessage(f"Starting processAction... {self.area}")
+        zone_name = self.area.GetZoneName()
+        wx.LogMessage(f"Zone name: {zone_name}")
+        if zone_name == "":
+            zone_name = f"zone{random.randint(0,100)}"
+            self.area.SetZoneName(zone_name)
 
-        config = {"HSpacing": self.m_txtHSpacing.GetValue(),
-                  "VSpacing": self.m_txtVSpacing.GetValue(),
-                  "Clearance": self.m_txtClearance.GetValue(),
-                  "Randomize": self.m_chkRandomize.GetValue()}
+        config = {
+            "HSpacing": self.m_txtHSpacing.GetValue(),
+            "VSpacing": self.m_txtVSpacing.GetValue(),
+            "Clearance": self.m_txtClearance.GetValue(),
+            "Randomize": self.m_chkRandomize.GetValue()}
 
-        with open(self.default_file_path, "w+") as def_file:
-            def_file.write(json.dumps(config))
+
+
+        if self.config_textbox == None:
+            self.config = {"ViaStitching": "0.1"
+                          }
+            title_block = pcbnew.PCB_TEXT(self.board)
+            title_block.SetLayer(self.config_layer)
+            title_block.SetHorizJustify(pcbnew.GR_TEXT_HJUSTIFY_LEFT)
+            title_block.SetVertJustify(pcbnew.GR_TEXT_VJUSTIFY_TOP)
+            self.config_textbox = title_block
+            self.board.Add(title_block)
+        self.config[zone_name] = config
+
+        self.config_textbox.SetText(json.dumps(self.config, indent=2))
 
         # Get overlapping items
         self.GetOverlappingItems()
 
         # Search trough groups
         for group in self.board.Groups():
-            if group.GetName() == __viagroupname__:
+            if group.GetName() == self.viagroupname:
                 self.pcb_group = group
 
         if self.pcb_group is None:
             self.pcb_group = pcbnew.PCB_GROUP(None)
-            self.pcb_group.SetName(__viagroupname__)
+            self.pcb_group.SetName(self.viagroupname)
             self.board.Add(self.pcb_group)
 
         self.FillupArea()
@@ -419,6 +460,20 @@ class ViaStitchingDialog(viastitching_gui):
         """Manage Close button click event."""
 
         self.Destroy()
+
+    def getConfigLayer(self):
+        self.config_layer = 0
+        user_layer = 0
+        for i in range(pcbnew.PCBNEW_LAYER_ID_START, pcbnew.PCBNEW_LAYER_ID_START + pcbnew.PCB_LAYER_ID_COUNT):
+            if __plugin_config_layer_name__ == pcbnew.BOARD_GetStandardLayerName(i):
+                self.config_layer = i
+                break
+            if "User.9" == pcbnew.BOARD_GetStandardLayerName(i):
+                user_layer = i
+        else:
+            self.config_layer = user_layer
+            self.board.SetLayerName(self.config_layer, __plugin_config_layer_name__)
+
 
 
 def InitViaStitchingDialog(board):

--- a/viastitching_dialog.py
+++ b/viastitching_dialog.py
@@ -21,7 +21,6 @@ try:
 except Exception:
     from math import sqrt, pow
 import json
-import pathlib
 
 _ = gettext.gettext
 __version__ = "0.2"
@@ -48,7 +47,6 @@ class ViaStitchingDialog(viastitching_gui):
         self.pcb_group = None
         self.clearance = 0
         self.board_edges = []
-        self.default_file_path = f"{pathlib.Path(__file__).parent.resolve()}/{default_filename}"
         self.config_layer = 0
         self.config_textbox = None
         self.area = None
@@ -68,7 +66,6 @@ class ViaStitchingDialog(viastitching_gui):
                         self.config = new_config
                 except JSONDecodeError:
                     pass
-        wx.LogMessage(f"Got config: {self.config}")
 
 
         # Use the same unit set int PCBNEW
@@ -102,7 +99,6 @@ class ViaStitchingDialog(viastitching_gui):
             # Populate nets checkbox
             self.PopulateNets()
 
-        wx.LogMessage(f"Area: {self.area}")
         defaults = self.config.get(self.area.GetZoneName(), None)
         self.viagroupname = __viagroupname_base__ + self.area.GetZoneName()
 
@@ -110,8 +106,6 @@ class ViaStitchingDialog(viastitching_gui):
         for group in self.board.Groups():
             if group.GetName() == self.viagroupname:
                 self.pcb_group = group
-
-        wx.LogMessage(f"Got defaults: {defaults}")
 
         if defaults is not None:
             self.m_txtVSpacing.SetValue(defaults.get("VSpacing", "3"))
@@ -132,10 +126,6 @@ class ViaStitchingDialog(viastitching_gui):
         self.m_txtViaDrillSize.SetValue("%.6f" % self.ToUserUnit(via_dims.m_Drill))
         via_dim_list.push_back(via_dims)
         self.overlappings = None
-
-        wx.LogMessage("Finished init...")
-
-
 
     def GetOverlappingItems(self):
         """Collect overlapping items.
@@ -194,7 +184,6 @@ class ViaStitchingDialog(viastitching_gui):
                     return False
                 self.area = area
                 self.net = area.GetNetname()
-                wx.LogMessage(f"Area: {self.area}!")
                 return True
 
         return False
@@ -406,9 +395,7 @@ class ViaStitchingDialog(viastitching_gui):
 
     def onProcessAction(self, event):
         """Manage main button (Ok) click event."""
-        wx.LogMessage(f"Starting processAction... {self.area}")
         zone_name = self.area.GetZoneName()
-        wx.LogMessage(f"Zone name: {zone_name}")
         if zone_name == "":
             for i in range(1000):
                 candidate_name = f"stitch_zone_{i}"
@@ -435,6 +422,7 @@ class ViaStitchingDialog(viastitching_gui):
             title_block.SetLayer(self.config_layer)
             title_block.SetHorizJustify(pcbnew.GR_TEXT_HJUSTIFY_LEFT)
             title_block.SetVertJustify(pcbnew.GR_TEXT_VJUSTIFY_TOP)
+            title_block.SetVisible(False)
             self.config_textbox = title_block
             self.board.Add(title_block)
         self.config[zone_name] = config


### PR DESCRIPTION
Multiple zones can be filled with individual settings. Each zone setting is now saved separately in a JSON dictionary stored in a text box on layer "User.9", which gets renamed as "plugins.config" after the first successful via stitching.