### PR TITLE
Add VOffset and HOffset configuration options to allow more precise via grid alignment

### DIFF
--- a/defaults.json
+++ b/defaults.json
@@ -1,1 +1,1 @@
-{"HSpacing": "2", "VSpacing": "2", "Clearance": "0", "Randomize": false}
+{"HSpacing": "2", "VSpacing": "2", "HOffset": "0", "VOffset": "0", "Clearance": "0", "Randomize": false}

--- a/viastitching_dialog.py
+++ b/viastitching_dialog.py
@@ -32,7 +32,8 @@ __plugin_config_layer_name__ = "plugins.config"
 GUI_defaults = {"to_units": {0: pcbnew.ToMils, 1: pcbnew.ToMM},
                 "from_units": {0: pcbnew.FromMils, 1: pcbnew.FromMM},
                 "unit_labels": {0: u"mils", 1: u"mm"},
-                "spacing": {0: "40", 1: "1"}}
+                "spacing": {0: "40", 1: "1"},
+                "offset": {0: "0", 1: "0"}}
 
 class ViaStitchingDialog(viastitching_gui):
     """Class that gathers all the GUI controls."""
@@ -106,6 +107,8 @@ class ViaStitchingDialog(viastitching_gui):
 
         self.m_txtVSpacing.SetValue(defaults.get("VSpacing", GUI_defaults["spacing"][units_mode]))
         self.m_txtHSpacing.SetValue(defaults.get("HSpacing", GUI_defaults["spacing"][units_mode]))
+        self.m_txtVOffset.SetValue(defaults.get("VOffset", GUI_defaults["offset"][units_mode]))
+        self.m_txtHOffset.SetValue(defaults.get("HOffset", GUI_defaults["offset"][units_mode]))
         self.m_txtClearance.SetValue(defaults.get("Clearance", "0"))
         self.m_chkRandomize.SetValue(defaults.get("Randomize", False))
 
@@ -341,6 +344,8 @@ class ViaStitchingDialog(viastitching_gui):
         viasize = self.FromUserUnit(float(self.m_txtViaSize.GetValue()))
         step_x = self.FromUserUnit(float(self.m_txtHSpacing.GetValue()))
         step_y = self.FromUserUnit(float(self.m_txtVSpacing.GetValue()))
+        offset_x = self.FromUserUnit(float(self.m_txtHOffset.GetValue()))
+        offset_y = self.FromUserUnit(float(self.m_txtVOffset.GetValue()))
         clearance = self.FromUserUnit(float(self.m_txtClearance.GetValue()))
         self.randomize = self.m_chkRandomize.GetValue()
         self.clearance = clearance
@@ -353,13 +358,13 @@ class ViaStitchingDialog(viastitching_gui):
         netcode = self.board.GetNetcodeFromNetname(netname)
         # commit = pcbnew.COMMIT()
         viacount = 0
-        x = left
+        x = (left + offset_x) % step_x
 
         # Cycle trough area bounding box checking and implanting vias
         layer_set = self.area.GetLayerSet()
         layers = list(layer_set.Seq())
         while x <= right:
-            y = top
+            y = (top + offset_y) % step_y
             while y <= bottom:
                 if self.randomize:
                     xp = x + random.uniform(-1, 1) * step_x / 5
@@ -421,6 +426,8 @@ class ViaStitchingDialog(viastitching_gui):
         config = {
             "HSpacing": self.m_txtHSpacing.GetValue(),
             "VSpacing": self.m_txtVSpacing.GetValue(),
+            "HOffset": self.m_txtHOffset.GetValue(),
+            "VOffset": self.m_txtVOffset.GetValue(),
             "Clearance": self.m_txtClearance.GetValue(),
             "Randomize": self.m_chkRandomize.GetValue()}
 

--- a/viastitching_gui.py
+++ b/viastitching_gui.py
@@ -86,6 +86,29 @@ class viastitching_gui ( wx.Dialog ):
 
 		bMainSizer.Add( bHSizer3, 1, wx.EXPAND, 5 )
 
+		bHSizer6 = wx.BoxSizer( wx.HORIZONTAL )
+
+		self.m_lblOffset = wx.StaticText( self, wx.ID_ANY, _(u"Offset (V/H)"), wx.DefaultPosition, wx.DefaultSize, 0 )
+		self.m_lblOffset.Wrap( -1 )
+
+		bHSizer6.Add( self.m_lblOffset, 0, wx.ALIGN_CENTER_VERTICAL|wx.ALL, 5 )
+
+		self.m_txtVOffset = wx.TextCtrl( self, wx.ID_ANY, wx.EmptyString, wx.DefaultPosition, wx.DefaultSize, 0 )
+		self.m_txtVOffset.SetMinSize( wx.Size( 120,-1 ) )		
+		bHSizer6.Add( self.m_txtVOffset, 0, wx.ALIGN_CENTER_VERTICAL|wx.ALL, 5 )
+
+		self.m_txtHOffset = wx.TextCtrl( self, wx.ID_ANY, wx.EmptyString, wx.DefaultPosition, wx.DefaultSize, 0 )
+		self.m_txtHOffset.SetMinSize( wx.Size( 120,-1 ) )		
+		bHSizer6.Add( self.m_txtHOffset, 0, wx.ALIGN_CENTER_VERTICAL|wx.ALL, 5 )
+
+		self.m_lblUnit2 = wx.StaticText( self, wx.ID_ANY, _(u"mm"), wx.DefaultPosition, wx.DefaultSize, 0 )
+		self.m_lblUnit2.Wrap( -1 )
+
+		bHSizer6.Add( self.m_lblUnit2, 0, wx.ALIGN_CENTER_VERTICAL|wx.ALL, 5 )
+
+
+		bMainSizer.Add( bHSizer6, 1, wx.EXPAND, 5 )
+
 		bSizer7 = wx.BoxSizer( wx.HORIZONTAL )
 
 		self.m_staticText6 = wx.StaticText( self, wx.ID_ANY, _(u"Clearance"), wx.DefaultPosition, wx.DefaultSize, 0 )


### PR DESCRIPTION
I needed to align my stitched vias more precisely with board with respect to my components. So I added an X and Y offset to bias the grid by a fixed amount. Previously it would always be aligned to the top left of the bounding box. Feel free to take this change if you want it.