### PR TITLE
Fix via stitching failing with overlapping zones

### DIFF
--- a/viastitching_dialog.py
+++ b/viastitching_dialog.py
@@ -144,8 +144,9 @@ class ViaStitchingDialog(viastitching_gui):
 
         for zone in self.board.Zones():
             if zone.GetZoneName() != self.area.GetZoneName():
-                if zone.GetBoundingBox().Intersects(area_bbox):
-                    self.overlappings.append(zone)
+                if zone.GetNetname() != self.net:
+                    if zone.GetBoundingBox().Intersects(area_bbox):
+                        self.overlappings.append(zone)
 
         for item in tracks:
             if (type(item) is pcbnew.PCB_VIA) and (item.GetBoundingBox().Intersects(area_bbox)):
@@ -327,8 +328,14 @@ class ViaStitchingDialog(viastitching_gui):
                 if item.GetBoundingBox().Intersects(via.GetBoundingBox()):
                     return True
             elif type(item).__name__ in ['ZONE', 'FP_ZONE', 'PCB_ZONE', 'ZONE_CONTAINER']:
-                if item.GetBoundingBox().Intersects(via.GetBoundingBox()):
-                    return True
+                via_layers = set(via.GetLayerSet().Seq())
+                zone_layers = set(item.GetLayerSet().Seq())
+                common_layers = via_layers & zone_layers
+                if common_layers:
+                    p = via.GetPosition()
+                    accuracy = via.GetWidth() // 2
+                    if any(item.HitTestFilledArea(layer, p, accuracy) for layer in common_layers):
+                        return True
             elif type(item) is pcbnew.PCB_TRACK:
                 if item.GetBoundingBox().Intersects(via.GetBoundingBox()):
                     width = item.GetWidth()


### PR DESCRIPTION
Bug fix written by Claude Opus 4.6 to fix #36:

Two bugs caused "No Vias Implanted" when zones overlap on the same layer with different priorities:

1. Same-net zones were treated as obstacles. The zone obstacle loop compared zone names but not nets, so a same-net overlapping zone (e.g. a higher-priority zone on the same net) would block all via placement. Added a net check to skip same-net zones.

2. Zone overlap detection used bounding-box intersection instead of actual filled area. This is far too coarse - the bounding box covers the full rectangular extent, rejecting vias well outside the real overlap. Replaced with HitTestFilledArea(), which checks against the actual filled copper and respects zone priority (KiCad's zone fill already carves lower-priority zones where higher-priority ones fill).