### PR TITLE
Properly check for overlap with round and custom pad shapes

### DIFF
--- a/viastitching_dialog.py
+++ b/viastitching_dialog.py
@@ -320,8 +320,15 @@ class ViaStitchingDialog(viastitching_gui):
 
         for item in self.overlappings:
             if type(item) is pcbnew.PAD:
-                if item.GetBoundingBox().Intersects(via.GetBoundingBox()):
-                    return True
+                # Check with HitTest() rather than GetBoundingBox() to handle round+custom pad shapes
+                via_layers = set(via.GetLayerSet().Seq())
+                pad_layers = set(item.GetLayerSet().Seq())
+                common_layers = via_layers & pad_layers
+                if common_layers:
+                    p = via.GetPosition()
+                    accuracy = via.GetWidth() // 2
+                    if any(item.HitTest(p, accuracy, layer) for layer in common_layers):
+                        return True
             elif type(item) is pcbnew.PCB_VIA:
                 # Overlapping with vias work best if checking is performed by intersection
                 if item.GetBoundingBox().Intersects(via.GetBoundingBox()):


### PR DESCRIPTION
A bounding box is not appropriate for checking whether a via intersects with round or custom pads. HitTest() allows for placement of vias near non-rectangular pads which would fail the simpler bounding box check. It follows the same pattern as the fix to zone overlaps made in #37.

I've tested this fix rebased atop #37 and #39 on KiCad v10.0.0, see [nathancheek/master](https://github.com/nathancheek/viastitching/commits/master/)

It seems slightly slower, which makes sense since `HitTestFilledArea()` is probably slower than a simpler bounding box check. But I think the performance hit is worth it for accurately filling in vias around non-rectangular pads.