### PR TITLE
Bug fix for user units selection mismatching KiCAD API, units labels …

### DIFF
--- a/viastitching_dialog.py
+++ b/viastitching_dialog.py
@@ -29,11 +29,11 @@ __plugin_name__ = "ViaStitching"
 __viagroupname_base__ = "VIA_STITCHING_GROUP"
 __plugin_config_layer_name__ = "plugins.config"
 
-GUI_defaults = {"to_units": {0: pcbnew.ToMils, 1: pcbnew.ToMM},
-                "from_units": {0: pcbnew.FromMils, 1: pcbnew.FromMM},
-                "unit_labels": {0: u"mils", 1: u"mm"},
-                "spacing": {0: "40", 1: "1"},
-                "offset": {0: "0", 1: "0"}}
+GUI_defaults = {"to_units": {5: pcbnew.ToMils, 1: pcbnew.ToMM},
+                "from_units": {5: pcbnew.FromMils, 1: pcbnew.FromMM},
+                "unit_labels": {5: u"mils", 1: u"mm"},
+                "spacing": {5: "40", 1: "1"},
+                "offset": {5: "0", 1: "0"}}
 
 class ViaStitchingDialog(viastitching_gui):
     """Class that gathers all the GUI controls."""
@@ -83,6 +83,12 @@ class ViaStitchingDialog(viastitching_gui):
             self.Destroy()
             return
 
+        # Check user unit is valid (Mils or MM)
+        if units_mode not in GUI_defaults["to_units"]:
+            wx.MessageBox(_(u"Unsupported unit selected"))
+            self.Destroy()
+            return
+
         # Check for selected area
         if not self.GetAreaConfig():
             wx.MessageBox(_(u"Please select a valid area"))
@@ -96,6 +102,7 @@ class ViaStitchingDialog(viastitching_gui):
         self.FromUserUnit = GUI_defaults["from_units"][units_mode]
         self.m_lblUnit1.SetLabel(_(GUI_defaults["unit_labels"][units_mode]))
         self.m_lblUnit2.SetLabel(_(GUI_defaults["unit_labels"][units_mode]))
+        self.m_lblUnit3.SetLabel(_(GUI_defaults["unit_labels"][units_mode]))
 
         defaults = self.config.get(self.area.GetZoneName(), {})
         self.viagroupname = __viagroupname_base__ + self.area.GetZoneName()

--- a/viastitching_gui.py
+++ b/viastitching_gui.py
@@ -101,10 +101,10 @@ class viastitching_gui ( wx.Dialog ):
 		self.m_txtHOffset.SetMinSize( wx.Size( 120,-1 ) )		
 		bHSizer6.Add( self.m_txtHOffset, 0, wx.ALIGN_CENTER_VERTICAL|wx.ALL, 5 )
 
-		self.m_lblUnit2 = wx.StaticText( self, wx.ID_ANY, _(u"mm"), wx.DefaultPosition, wx.DefaultSize, 0 )
-		self.m_lblUnit2.Wrap( -1 )
+		self.m_lblUnit3 = wx.StaticText( self, wx.ID_ANY, _(u"mm"), wx.DefaultPosition, wx.DefaultSize, 0 )
+		self.m_lblUnit3.Wrap( -1 )
 
-		bHSizer6.Add( self.m_lblUnit2, 0, wx.ALIGN_CENTER_VERTICAL|wx.ALL, 5 )
+		bHSizer6.Add( self.m_lblUnit3, 0, wx.ALIGN_CENTER_VERTICAL|wx.ALL, 5 )
 
 
 		bMainSizer.Add( bHSizer6, 1, wx.EXPAND, 5 )


### PR DESCRIPTION
Addressing issue: https://github.com/weirdgyn/viastitching/issues/42



Switched mils int to 5 to match KiCAD API

Added graceful fail if unexpected unit is selected (for instance inch not implemented)

Updated dialog to toggle mils / mm text for offset text



Tested generation with inches selected (failed as expected)
<img width="1136" height="664" alt="image" src="https://github.com/user-attachments/assets/3c0d886b-f56e-4bfe-8160-fb34e6f2af09" />

Tested generation with mils selected (worked as expected)
<img width="1193" height="654" alt="image" src="https://github.com/user-attachments/assets/5c622487-34be-4401-841c-de095d6b2d94" />

Tested generation with mm selected (worked as expected)
<img width="1227" height="825" alt="image" src="https://github.com/user-attachments/assets/910d63d1-eb97-4630-9889-6f3787aa2db8" />
