### PR TITLE
Place vias only on filled copper of the selected net across all layers

### DIFF
--- a/viastitching_dialog.py
+++ b/viastitching_dialog.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python
 
-# ViaStitching for pcbnew 
+# ViaStitching for pcbnew
 # This is the plugin WX dialog
 # (c) Michele Santucci 2019
 #
@@ -17,6 +17,7 @@ from .viastitching_gui import viastitching_gui
 numpy_available = False
 try:
     import numpy as np
+
     numpy_available = True
 except Exception:
     from math import sqrt, pow
@@ -25,15 +26,18 @@ import json
 _ = gettext.gettext
 __version__ = "0.2"
 __plugin_name__ = "ViaStitching"
-#__timecode__ = 1972
+# __timecode__ = 1972
 __viagroupname_base__ = "VIA_STITCHING_GROUP"
 __plugin_config_layer_name__ = "plugins.config"
 
-GUI_defaults = {"to_units": {5: pcbnew.ToMils, 1: pcbnew.ToMM},
-                "from_units": {5: pcbnew.FromMils, 1: pcbnew.FromMM},
-                "unit_labels": {5: u"mils", 1: u"mm"},
-                "spacing": {5: "40", 1: "1"},
-                "offset": {5: "0", 1: "0"}}
+GUI_defaults = {
+    "to_units": {5: pcbnew.ToMils, 1: pcbnew.ToMM},
+    "from_units": {5: pcbnew.FromMils, 1: pcbnew.FromMM},
+    "unit_labels": {5: "mils", 1: "mm"},
+    "spacing": {5: "40", 1: "1"},
+    "offset": {5: "0", 1: "0"},
+}
+
 
 class ViaStitchingDialog(viastitching_gui):
     """Class that gathers all the GUI controls."""
@@ -43,7 +47,7 @@ class ViaStitchingDialog(viastitching_gui):
 
         super(ViaStitchingDialog, self).__init__(None)
         self.viagroupname = None
-        self.SetTitle(_(u"{0} v{1}").format(__plugin_name__, __version__))
+        self.SetTitle(_("{0} v{1}").format(__plugin_name__, __version__))
         self.Bind(wx.EVT_CLOSE, self.onCloseWindow)
         self.m_btnCancel.Bind(wx.EVT_BUTTON, self.onCloseWindow)
         self.m_btnOk.Bind(wx.EVT_BUTTON, self.onProcessAction)
@@ -62,7 +66,7 @@ class ViaStitchingDialog(viastitching_gui):
         self.getConfigLayer()
 
         for d in pcbnew.GetBoard().GetDrawings():
-            if d.GetLayerName() == 'Edge.Cuts':
+            if d.GetLayerName() == "Edge.Cuts":
                 self.board_edges.append(d)
             if d.GetLayerName() == __plugin_config_layer_name__:
                 try:
@@ -73,25 +77,24 @@ class ViaStitchingDialog(viastitching_gui):
                 except (JSONDecodeError, AttributeError):
                     pass
 
-
         # Use the same unit set int PCBNEW
         self.ToUserUnit = None
         self.FromUserUnit = None
         units_mode = pcbnew.GetUserUnits()
         if units_mode == -1:
-            wx.MessageBox(_(u"Not a valid frame"))
+            wx.MessageBox(_("Not a valid frame"))
             self.Destroy()
             return
 
         # Check user unit is valid (Mils or MM)
         if units_mode not in GUI_defaults["to_units"]:
-            wx.MessageBox(_(u"Unsupported unit selected"))
+            wx.MessageBox(_("Unsupported unit selected"))
             self.Destroy()
             return
 
         # Check for selected area
         if not self.GetAreaConfig():
-            wx.MessageBox(_(u"Please select a valid area"))
+            wx.MessageBox(_("Please select a valid area"))
             self.Destroy()
             return
 
@@ -112,10 +115,18 @@ class ViaStitchingDialog(viastitching_gui):
             if group.GetName() == self.viagroupname:
                 self.pcb_group = group
 
-        self.m_txtVSpacing.SetValue(defaults.get("VSpacing", GUI_defaults["spacing"][units_mode]))
-        self.m_txtHSpacing.SetValue(defaults.get("HSpacing", GUI_defaults["spacing"][units_mode]))
-        self.m_txtVOffset.SetValue(defaults.get("VOffset", GUI_defaults["offset"][units_mode]))
-        self.m_txtHOffset.SetValue(defaults.get("HOffset", GUI_defaults["offset"][units_mode]))
+        self.m_txtVSpacing.SetValue(
+            defaults.get("VSpacing", GUI_defaults["spacing"][units_mode])
+        )
+        self.m_txtHSpacing.SetValue(
+            defaults.get("HSpacing", GUI_defaults["spacing"][units_mode])
+        )
+        self.m_txtVOffset.SetValue(
+            defaults.get("VOffset", GUI_defaults["offset"][units_mode])
+        )
+        self.m_txtHOffset.SetValue(
+            defaults.get("HOffset", GUI_defaults["offset"][units_mode])
+        )
         self.m_txtClearance.SetValue(defaults.get("Clearance", "0"))
         self.m_chkRandomize.SetValue(defaults.get("Randomize", False))
 
@@ -125,7 +136,7 @@ class ViaStitchingDialog(viastitching_gui):
         if via_dim_list:
             via_dims = via_dim_list.pop()
         else:
-            wx.MessageBox(_(u"Please set via drill/size in board"))
+            wx.MessageBox(_("Please set via drill/size in board"))
             self.Destroy()
 
         self.m_txtViaSize.SetValue("%.6f" % self.ToUserUnit(via_dims.m_Diameter))
@@ -135,12 +146,12 @@ class ViaStitchingDialog(viastitching_gui):
 
     def GetOverlappingItems(self):
         """Collect overlapping items.
-            Every bounding box of any item found is a candidate to be inspected for overlapping.
+        Every bounding box of any item found is a candidate to be inspected for overlapping.
         """
 
         area_bbox = self.area.GetBoundingBox()
 
-        if hasattr(self.board, 'GetModules'):
+        if hasattr(self.board, "GetModules"):
             modules = self.board.GetModules()
         else:
             modules = self.board.GetFootprints()
@@ -156,7 +167,9 @@ class ViaStitchingDialog(viastitching_gui):
                         self.overlappings.append(zone)
 
         for item in tracks:
-            if (type(item) is pcbnew.PCB_VIA) and (item.GetBoundingBox().Intersects(area_bbox)):
+            if (type(item) is pcbnew.PCB_VIA) and (
+                item.GetBoundingBox().Intersects(area_bbox)
+            ):
                 self.overlappings.append(item)
             if type(item) is pcbnew.PCB_TRACK:
                 self.overlappings.append(item)
@@ -187,9 +200,15 @@ class ViaStitchingDialog(viastitching_gui):
             if area.IsSelected():
                 if not area.IsOnCopperLayer():
                     return False
-                elif hasattr(area, 'GetDoNotAllowCopperPour') and area.GetDoNotAllowCopperPour():
+                elif (
+                    hasattr(area, "GetDoNotAllowCopperPour")
+                    and area.GetDoNotAllowCopperPour()
+                ):
                     return False
-                elif hasattr(area, 'GetDoNotAllowZoneFills') and area.GetDoNotAllowZoneFills():
+                elif (
+                    hasattr(area, "GetDoNotAllowZoneFills")
+                    and area.GetDoNotAllowZoneFills()
+                ):
                     return False
                 self.area = area
                 self.net = area.GetNetname()
@@ -222,7 +241,7 @@ class ViaStitchingDialog(viastitching_gui):
         viasize = self.FromUserUnit(float(self.m_txtViaSize.GetValue()))
         netname = self.m_cbNet.GetStringSelection()
         netcode = self.board.GetNetcodeFromNetname(netname)
-        #commit = pcbnew.COMMIT()
+        # commit = pcbnew.COMMIT()
         viacount = 0
 
         for item in self.board.GetTracks():
@@ -233,21 +252,27 @@ class ViaStitchingDialog(viastitching_gui):
                 # if undo and (item.GetTimeStamp() == __timecode__):
                 if undo and (self.pcb_group is not None):
                     group = item.GetParentGroup()
-                    if (group is not None and group.GetName() == self.viagroupname):
+                    if group is not None and group.GetName() == self.viagroupname:
                         self.board.Remove(item)
                         viacount += 1
                         # commit.Remove(item)
-                elif (not undo) and self.area.HitTestFilledArea(self.area.GetLayer(), item.GetPosition(), 0) and (
-                        item.GetDrillValue() == drillsize) and (item.GetWidth() == viasize) and (
-                        item.GetNetname() == netname):
+                elif (
+                    (not undo)
+                    and self.area.HitTestFilledArea(
+                        self.area.GetLayer(), item.GetPosition(), 0
+                    )
+                    and (item.GetDrillValue() == drillsize)
+                    and (item.GetWidth() == viasize)
+                    and (item.GetNetname() == netname)
+                ):
                     self.board.Remove(item)
                     self.pcb_group.RemoveItem(item)
                     viacount += 1
                     # commit.Remove(item)
 
         if viacount > 0:
-            wx.MessageBox(_(u"Removed: %d vias!") % viacount)
-            #commit.Push()
+            wx.MessageBox(_("Removed: %d vias!") % viacount)
+            # commit.Push()
             pcbnew.Refresh()
 
     def CheckClearance(self, via, area, clearance):
@@ -269,7 +294,7 @@ class ViaStitchingDialog(viastitching_gui):
         for i in range(corners):
             corner = area.GetCornerPosition(i)
             # Handle both VECTOR2I and wxPoint
-            if hasattr(corner, 'getWxPoint'):
+            if hasattr(corner, "getWxPoint"):
                 p2 = corner.getWxPoint()
             else:
                 p2 = corner  # VECTOR2I can be used directly
@@ -282,7 +307,7 @@ class ViaStitchingDialog(viastitching_gui):
             corner1 = area.GetCornerPosition(i)
             corner2 = area.GetCornerPosition((i + 1) % corners)
             # Handle both VECTOR2I and wxPoint
-            if hasattr(corner1, 'getWxPoint'):
+            if hasattr(corner1, "getWxPoint"):
                 pc1 = corner1.getWxPoint()
                 pc2 = corner2.getWxPoint()
             else:
@@ -294,19 +319,22 @@ class ViaStitchingDialog(viastitching_gui):
                 return False
 
         for edge in self.board_edges:
-            if edge.ShowShape() == 'Line':
+            if edge.ShowShape() == "Line":
                 the_distance, _ = pnt2line(p1, edge.GetStart(), edge.GetEnd())
                 if the_distance <= clearance + via.GetWidth() / 2:
                     return False
-            if edge.ShowShape() == 'Arc':
+            if edge.ShowShape() == "Arc":
                 # distance from center of Arc and with angle within Arc angle should be outside Arc radius +- clearance + via Width/2
                 center = edge.GetPosition()
                 start = edge.GetStart()
                 end = edge.GetEnd()
                 radius = norm(center - end)
                 dist = norm(p1 - center)
-                if radius - (self.clearance + via.GetWidth() / 2) < dist < radius + (
-                        self.clearance + via.GetWidth() / 2):
+                if (
+                    radius - (self.clearance + via.GetWidth() / 2)
+                    < dist
+                    < radius + (self.clearance + via.GetWidth() / 2)
+                ):
                     # via is in range need to check the angle
                     start_angle = math.atan2((start - center).y, (start - center).x)
                     end_angle = math.atan2((end - center).y, (end - center).x)
@@ -317,17 +345,18 @@ class ViaStitchingDialog(viastitching_gui):
                         return False
 
         return True
+
     def CheckOverlap(self, via):
         """Check if via overlaps or interfere with other items on the board."""
-        
-        safe_margin = pcbnew.FromMM(0.35) 
+
+        safe_margin = pcbnew.FromMM(0.35)
         min_hole_dist = pcbnew.FromMM(0.5)
-        
+
         # --- 0. Edge ccuts check (Edge.Cuts) ---
         # set edge cuts range clearance (es. 0.5 mm)
-        edge_clearance = pcbnew.FromMM(0.5) 
+        edge_clearance = pcbnew.FromMM(0.5)
         check_dist = int(via.GetWidth() // 2 + edge_clearance)
-        
+
         for edge in self.board_edges:
             if edge.HitTest(via.GetPosition(), check_dist):
                 return True
@@ -337,22 +366,27 @@ class ViaStitchingDialog(viastitching_gui):
         via_bbox.Inflate(safe_margin)
 
         for item in self.overlappings:
-            
-            # 1. ignore copper filled zones 
-            if type(item).__name__ in ['ZONE', 'FP_ZONE', 'PCB_ZONE', 'ZONE_CONTAINER']:
+            # 1. ignore copper filled zones
+            if type(item).__name__ in ["ZONE", "FP_ZONE", "PCB_ZONE", "ZONE_CONTAINER"]:
                 continue
 
-            # 2. handling of the same net points 
-            if hasattr(item, 'GetNetCode') and item.GetNetCode() == via.GetNetCode():
+            # 2. handling of the same net points
+            if hasattr(item, "GetNetCode") and item.GetNetCode() == via.GetNetCode():
                 if type(item) is pcbnew.PCB_TRACK:
-                    continue 
+                    continue
                 elif type(item) is pcbnew.PCB_VIA:
                     # if same net check clearance
-                    dist = math.hypot(via.GetPosition().x - item.GetPosition().x, via.GetPosition().y - item.GetPosition().y)
-                    if dist < (via.GetDrillValue() / 2 + item.GetDrillValue() / 2 + min_hole_dist):
+                    dist = math.hypot(
+                        via.GetPosition().x - item.GetPosition().x,
+                        via.GetPosition().y - item.GetPosition().y,
+                    )
+                    if dist < (
+                        via.GetDrillValue() / 2
+                        + item.GetDrillValue() / 2
+                        + min_hole_dist
+                    ):
                         return True
                     continue
-                
 
             # 3. check collisions with Pads
             if type(item) is pcbnew.PAD:
@@ -364,20 +398,28 @@ class ViaStitchingDialog(viastitching_gui):
                     accuracy = int(via.GetWidth() // 2 + safe_margin)
                     if any(item.HitTest(p, accuracy, layer) for layer in common_layers):
                         return True
-                        
+
             # 4. check collisions with VIAS (other nets)
             elif type(item) is pcbnew.PCB_VIA:
                 if item.GetBoundingBox().Intersects(via_bbox):
                     return True
-                    
+
             # 5. check collisions with other tracks (other nets)
             elif type(item) is pcbnew.PCB_TRACK:
                 if item.GetBoundingBox().Intersects(via_bbox):
                     width = item.GetWidth()
-                    dist, _ = pnt2line(via.GetPosition(), item.GetStart(), item.GetEnd())
-                    if dist <= self.clearance + width // 2 + via.GetWidth() / 2 + safe_margin:
+                    dist, _ = pnt2line(
+                        via.GetPosition(), item.GetStart(), item.GetEnd()
+                    )
+                    if (
+                        dist
+                        <= self.clearance
+                        + width // 2
+                        + via.GetWidth() / 2
+                        + safe_margin
+                    ):
                         return True
-                        
+
         return False
         for item in self.overlappings:
             if type(item) is pcbnew.PAD:
@@ -394,23 +436,32 @@ class ViaStitchingDialog(viastitching_gui):
                 # Overlapping with vias work best if checking is performed by intersection
                 if item.GetBoundingBox().Intersects(via.GetBoundingBox()):
                     return True
-            elif type(item).__name__ in ['ZONE', 'FP_ZONE', 'PCB_ZONE', 'ZONE_CONTAINER']:
+            elif type(item).__name__ in [
+                "ZONE",
+                "FP_ZONE",
+                "PCB_ZONE",
+                "ZONE_CONTAINER",
+            ]:
                 via_layers = set(via.GetLayerSet().Seq())
                 zone_layers = set(item.GetLayerSet().Seq())
                 common_layers = via_layers & zone_layers
                 if common_layers:
                     p = via.GetPosition()
                     accuracy = via.GetWidth() // 2
-                    if any(item.HitTestFilledArea(layer, p, accuracy) for layer in common_layers):
+                    if any(
+                        item.HitTestFilledArea(layer, p, accuracy)
+                        for layer in common_layers
+                    ):
                         return True
             elif type(item) is pcbnew.PCB_TRACK:
                 if item.GetBoundingBox().Intersects(via.GetBoundingBox()):
                     width = item.GetWidth()
-                    dist, _ = pnt2line(via.GetPosition(), item.GetStart(), item.GetEnd())
+                    dist, _ = pnt2line(
+                        via.GetPosition(), item.GetStart(), item.GetEnd()
+                    )
                     if dist <= self.clearance + width // 2 + via.GetWidth() / 2:
                         return True
         return False
-
     def FillupArea(self):
         """Fills selected area with vias."""
 
@@ -447,10 +498,10 @@ class ViaStitchingDialog(viastitching_gui):
                     xp = x
                     yp = y
 
-                if hasattr(pcbnew, 'VECTOR2I'):
+                if hasattr(pcbnew, "VECTOR2I"):
                     p = pcbnew.VECTOR2I(int(xp), int(yp))
                 else:
-                    if(hasattr(pcbnew, 'wxPoint')):
+                    if hasattr(pcbnew, "wxPoint"):
                         p = pcbnew.wxPoint(int(xp), int(yp))
 
                 if any(self.area.HitTestFilledArea(layer, p, 0) for layer in layers):
@@ -466,7 +517,9 @@ class ViaStitchingDialog(viastitching_gui):
                     # via.SetTimeStamp(__timecode__)
                     if not self.CheckOverlap(via):
                         # Check clearance only if clearance value differs from 0 (disabled)
-                        if (clearance == 0) or self.CheckClearance(via, self.area, clearance):
+                        if (clearance == 0) or self.CheckClearance(
+                            via, self.area, clearance
+                        ):
                             via.SetWidth(viasize)
                             via.SetDrill(drillsize)
                             self.board.Add(via)
@@ -477,11 +530,11 @@ class ViaStitchingDialog(viastitching_gui):
             x += step_x
 
         if viacount > 0:
-            wx.MessageBox(_(u"Implanted: %d vias!") % viacount)
+            wx.MessageBox(_("Implanted: %d vias!") % viacount)
             # commit.Push()
             pcbnew.Refresh()
         else:
-            wx.MessageBox(_(u"No vias implanted!"))
+            wx.MessageBox(_("No vias implanted!"))
 
     def onProcessAction(self, event):
         """Manage main button (Ok) click event."""
@@ -493,7 +546,9 @@ class ViaStitchingDialog(viastitching_gui):
                     zone_name = candidate_name
                     break
             else:
-                wx.LogError("Tried 1000 different names and all were taken. Please give a name to the zone.")
+                wx.LogError(
+                    "Tried 1000 different names and all were taken. Please give a name to the zone."
+                )
                 self.Destroy()
             self.area.SetZoneName(zone_name)
 
@@ -503,25 +558,25 @@ class ViaStitchingDialog(viastitching_gui):
             "HOffset": self.m_txtHOffset.GetValue(),
             "VOffset": self.m_txtVOffset.GetValue(),
             "Clearance": self.m_txtClearance.GetValue(),
-            "Randomize": self.m_chkRandomize.GetValue()}
+            "Randomize": self.m_chkRandomize.GetValue(),
+        }
 
         if self.config_textbox is None:
-            self.config = {__plugin_name__: __version__
-                          }
+            self.config = {__plugin_name__: __version__}
             title_block = pcbnew.PCB_TEXT(self.board)
             title_block.SetLayer(self.config_layer)
-            
-            if hasattr(pcbnew, 'GR_TEXT_HJUSTIFY_LEFT'):
+
+            if hasattr(pcbnew, "GR_TEXT_HJUSTIFY_LEFT"):
                 title_block.SetHorizJustify(pcbnew.GR_TEXT_HJUSTIFY_LEFT)
             else:
-                if hasattr(pcbnew, 'GR_TEXT_H_ALIGN_LEFT'):
+                if hasattr(pcbnew, "GR_TEXT_H_ALIGN_LEFT"):
                     title_block.SetHorizJustify(pcbnew.GR_TEXT_H_ALIGN_LEFT)
 
-            if hasattr(pcbnew, 'GR_TEXT_VJUSTIFY_TOP'):
+            if hasattr(pcbnew, "GR_TEXT_VJUSTIFY_TOP"):
                 title_block.SetVertJustify(pcbnew.GR_TEXT_VJUSTIFY_TOP)
             else:
-                if hasattr(pcbnew, 'GR_TEXT_V_ALIGN_TOP'):
-                    title_block.SetVertJustify(pcbnew.GR_TEXT_V_ALIGN_TOP)                   
+                if hasattr(pcbnew, "GR_TEXT_V_ALIGN_TOP"):
+                    title_block.SetVertJustify(pcbnew.GR_TEXT_V_ALIGN_TOP)
 
             title_block.SetVisible(False)
             self.config_textbox = title_block
@@ -558,17 +613,20 @@ class ViaStitchingDialog(viastitching_gui):
         self.Destroy()
 
     def GetStandardLayerName(self, layerid):
-        if hasattr(pcbnew, 'BOARD_GetStandardLayerName'):
+        if hasattr(pcbnew, "BOARD_GetStandardLayerName"):
             layer_name = pcbnew.BOARD_GetStandardLayerName(layerid)
         else:
             layer_name = self.board.GetStandardLayerName(layerid)
-        
+
         return layer_name
 
     def getConfigLayer(self):
         self.config_layer = 0
         user_layer = 0
-        for i in range(pcbnew.PCBNEW_LAYER_ID_START, pcbnew.PCBNEW_LAYER_ID_START + pcbnew.PCB_LAYER_ID_COUNT):
+        for i in range(
+            pcbnew.PCBNEW_LAYER_ID_START,
+            pcbnew.PCBNEW_LAYER_ID_START + pcbnew.PCB_LAYER_ID_COUNT,
+        ):
             if __plugin_config_layer_name__ == self.GetStandardLayerName(i):
                 self.config_layer = i
                 break
@@ -579,7 +637,6 @@ class ViaStitchingDialog(viastitching_gui):
             self.board.SetLayerName(self.config_layer, __plugin_config_layer_name__)
 
 
-
 def InitViaStitchingDialog(board):
     """Initalize dialog."""
 
@@ -588,8 +645,7 @@ def InitViaStitchingDialog(board):
     return dlg
 
 
-class aVector():
-
+class aVector:
     def __init__(self, point: [pcbnew.wxPoint, list]):
         if isinstance(point, pcbnew.wxPoint):
             self.x = float(point.x)
@@ -636,6 +692,7 @@ class aVector():
 # 9  Calculate the distance from nearest to pnt_vec_scaled.
 # 10 Translate nearest back to the start/end line.
 # Malcolm Kesson 16 Dec 2012
+
 
 def pnt2line(point: pcbnew.wxPoint, start: pcbnew.wxPoint, end: pcbnew.wxPoint):
     pnt = vector([point.x, point.y])

--- a/viastitching_dialog.py
+++ b/viastitching_dialog.py
@@ -462,6 +462,34 @@ class ViaStitchingDialog(viastitching_gui):
                     if dist <= self.clearance + width // 2 + via.GetWidth() / 2:
                         return True
         return False
+
+    def HasFilledCopperAt(self, position, layers, netcode, radius):
+        """Return whether the selected net has filled copper around a via."""
+
+        samples = [position]
+        for index in range(32):
+            angle = 2 * math.pi * index / 32
+            sample_x = int(position.x + radius * math.cos(angle))
+            sample_y = int(position.y + radius * math.sin(angle))
+            if hasattr(pcbnew, "VECTOR2I"):
+                samples.append(pcbnew.VECTOR2I(sample_x, sample_y))
+            else:
+                samples.append(pcbnew.wxPoint(sample_x, sample_y))
+
+        zones = [zone for zone in self.board.Zones() if zone.GetNetCode() == netcode]
+        for layer in layers:
+            if not all(
+                any(
+                    zone.HitTestFilledArea(layer, sample, 0)
+                    for zone in zones
+                    if layer in set(zone.GetLayerSet().Seq())
+                )
+                for sample in samples
+            ):
+                return False
+
+        return True
+
     def FillupArea(self):
         """Fills selected area with vias."""
 
@@ -504,7 +532,7 @@ class ViaStitchingDialog(viastitching_gui):
                     if hasattr(pcbnew, "wxPoint"):
                         p = pcbnew.wxPoint(int(xp), int(yp))
 
-                if any(self.area.HitTestFilledArea(layer, p, 0) for layer in layers):
+                if self.HasFilledCopperAt(p, layers, netcode, viasize / 2):
                     via = pcbnew.PCB_VIA(self.board)
                     via.SetPosition(p)
                     via.SetLayerSet(layer_set)


### PR DESCRIPTION
## Summary

Fixes via placement in overlapping / complex zone scenarios.

Previously a via was placed whenever a candidate point hit the *selected zone's
own* filled area (`self.area.HitTestFilledArea(...)`). This produced vias on
copper that belonged to other nets, and vias sitting in areas where overlapping
zones cut out the pour.

Example: 
<img width="1909" height="1139" alt="image" src="https://github.com/user-attachments/assets/3b2f5da1-fee2-4fb1-9a00-8a95978b33e1" />
[test.zip](https://github.com/user-attachments/files/30617193/test.zip)


## Changes

`viastitching_dialog.py`: added `HasFilledCopperAt()` and used it in `FillupArea()`.

- Considers only board zones assigned to the **selected net**.
- Tests the **actually filled** copper (`ZONE.HitTestFilledArea`), so overlapping
  zones, cutouts, and unfilled zones are handled correctly instead of relying on
  the selected zone outline.
- Samples the via center plus 32 points along the via circumference.
- Requires **every layer** of the selected area to have filled copper of the
  selected net covering the whole via — a via is rejected when only one side has
  copper (e.g. GND pour on F.Cu but not B.Cu).

Chore: I also do fmt on the codebase, so the changes are a bit messy. You can inspect https://github.com/weirdgyn/viastitching/commit/6754be359dc61230248415036631e1a5c6e2f7d1 for actual functional changes.

## Commits

- `Format code for consistency` — formatting only, no behavior change
- `Place vias only on filled copper of the selected net across all layers` — the functional change

## Testing

Verified against a fairly complected board with overlapping multi-net zones. Candidates that were
previously accepted are now correctly rejected when net or layer copper coverage
is incomplete.
<img width="1613" height="1318" alt="image" src="https://github.com/user-attachments/assets/3a28b9c2-046c-4bba-b3dc-010ce898b18d" />
