### PR TITLE
Keep stitched via nets fixed

### DIFF
--- a/viastitching_dialog.py
+++ b/viastitching_dialog.py
@@ -537,6 +537,9 @@ class ViaStitchingDialog(viastitching_gui):
                     via.SetPosition(p)
                     via.SetLayerSet(layer_set)
                     via.SetNetCode(netcode)
+                    if hasattr(via, "SetIsFree"):
+                        # Free vias keep the selected net instead of auto-updating from zones.
+                        via.SetIsFree(True)
                     # Set up via with clearance added to its size-> bounding box check will be OK in worst case, may be too conservative, but additional checks are possible if needed
                     # TODO: possibly take the clearance from the PCB settings instead of the dialog
                     # Clearance is all around -> *2


### PR DESCRIPTION
## Summary
- mark generated stitching vias as free vias with SetIsFree(True)
- keep the selected net assigned instead of allowing zone-based automatic via net updates to change it later

## Root cause
The plugin sets the selected net code while creating a PCB_VIA, but the via remains eligible for KiCad's automatic via net update. On boards with multiple filled zones, KiCad can later reassign those vias to a different surrounding zone net.

## Validation
- compiled viastitching_dialog.py with KiCad's bundled Python
- verified a KiCad PCB_VIA with SetIsFree(True) saves as (free yes) in a .kicad_pcb file